### PR TITLE
Fix environement variable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ API with high performance built with FastAPI & SQLAlchemy, help to improve conne
 - FastAPI
 - Docker
 
-### Project setup
+### Project Setup
 
 ```sh
 # clone the repo
@@ -33,7 +33,7 @@ $ git clone https://github.com/yezz123/DogeAPI
 $ cd DogeAPI
 ```
 
-### Creating virtual environment
+### Creating Virtual Environment
 
 - Create a virtual environment using virtualenv.
 
@@ -57,7 +57,7 @@ $ pip install -r requirements.txt
 $ uvicorn main:app --reload
 ```
 
-### Environment variables
+### Environment Variables
 
 - `SECRET_KEY`: A secret key for signing Json Web Token.
 - `SQLALCHEMY_DATABASE_URL`: The database url to connect to the database.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ uvicorn main:app --reload
 ### Environment Variables
 
 - `SECRET_KEY`: A secret key for signing Json Web Token.
-- `SQLALCHEMY_DATABASE_URL`: The database url to connect to the database.
+- `DATABASE_URL`: The database url to connect to the database.
 - `ACCESS_TOKEN_EXPIRE_MINUTES`: The access token expire minutes.
 
 > change all the environment variables in the `.env.sample` and don't forget to rename it to `.env`.


### PR DESCRIPTION
At the [`.env.sample`](https://github.com/yezz123/DogeAPI/blob/main/.env.sample) file it expects a `DATABASE_URL` variable to be set but in the README it is specified as `SQLALCHEMY_DATABASE_URL`.