### PR TITLE
Fix environment variable defaults

### DIFF
--- a/database/configuration.py
+++ b/database/configuration.py
@@ -5,8 +5,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./database/dogeapi.sqlite" or config(
-    "DATABASE_URL"
+SQLALCHEMY_DATABASE_URL = config(
+    "DATABASE_URL", default="sqlite:///./database/dogeapi.sqlite"
 )
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}

--- a/schema/token.py
+++ b/schema/token.py
@@ -9,9 +9,9 @@ from jose import JWTError, jwt
 from schema.schemas import TokenData
 
 # openssl rand -hex 32
-SECRET_KEY = "secret" or config("SECRET_KEY")
+SECRET_KEY = config("SECRET_KEY", default="secret")
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 60 or config(
+ACCESS_TOKEN_EXPIRE_MINUTES = config(
     "ACCESS_TOKEN_EXPIRE_MINUTES", default=60, cast=int
 )
 


### PR DESCRIPTION
In the following snippet, the value of the `SQLALCHEMY_DATABASE_URL` will always be `"sqlite:///./database/dogeapi.sqlite"` and the environment variable will not be counted.

```python
SQLALCHEMY_DATABASE_URL = "sqlite:///./database/dogeapi.sqlite" or config(
    "DATABASE_URL"
)
```

The same situation is here - `SECRET_KEY` will always be `"secret"` and the `ACCESS_TOKEN_EXPIRE_MINUTES`, `60` as they come before `or` operation and have positive boolean value (`True`).

```python
SECRET_KEY = "secret" or config("SECRET_KEY")
ALGORITHM = "HS256"
ACCESS_TOKEN_EXPIRE_MINUTES = 60 or config(
    "ACCESS_TOKEN_EXPIRE_MINUTES", default=60, cast=int
)
```

### Summary

This pull request suggests using the `default` parameter of the `decouple.config`.

Thanks for your review.