### PR TITLE
feat: integrate httrace HTTP traffic capture middleware

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -45,8 +45,11 @@ stripe = [
 logfire = [
     "logfire[fastapi,sqlalchemy,redis,httpx]>=4.32.1",
 ]
+httrace = [
+    "httrace>=0.1.1",
+]
 all = [
-    "dogeapi[email,oauth,ai,stripe,logfire]",
+    "dogeapi[email,oauth,ai,stripe,logfire,httrace]",
 ]
 
 [dependency-groups]
@@ -114,7 +117,7 @@ disallow_untyped_defs = true
 exclude = ["alembic/versions/", "tests/"]
 
 [[tool.mypy.overrides]]
-module = ["resend.*", "stripe.*", "authlib.*", "logfire.*", "fastapi_llm_gateway.*"]
+module = ["resend.*", "stripe.*", "authlib.*", "logfire.*", "fastapi_llm_gateway.*", "httrace.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/backend/src/dogeapi/main.py
+++ b/backend/src/dogeapi/main.py
@@ -162,6 +162,17 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
         app.include_router(ai_router)
 
+    if settings.FEATURE_HTTRACE and settings.HTTRACE_API_KEY:
+        from httrace import HttraceCaptureMiddleware
+
+        app.add_middleware(
+            HttraceCaptureMiddleware,
+            api_key=settings.HTTRACE_API_KEY,
+            service=settings.HTTRACE_SERVICE,
+            sample_rate=settings.HTTRACE_SAMPLE_RATE,
+            exclude_paths=["/healthz", "/metrics", "/favicon.ico"],
+        )
+
     # Admin endpoints are always-on; the dependency rejects non-superadmins.
     from dogeapi.admin.router import router as admin_router
 

--- a/backend/src/dogeapi/settings.py
+++ b/backend/src/dogeapi/settings.py
@@ -61,6 +61,11 @@ class Settings(BaseSettings):
     FEATURE_AI_CHAT: bool = False
     FEATURE_LOGFIRE: bool = False
     FEATURE_STRIPE: bool = False
+    FEATURE_HTTRACE: bool = False
+
+    HTTRACE_API_KEY: str = ""
+    HTTRACE_SERVICE: str = "ai-template"
+    HTTRACE_SAMPLE_RATE: float = 0.1
 
     EMAIL_PROVIDER: EmailProvider = "smtp"
     EMAIL_FROM: str = "AI Template <noreply@dogeapi.local>"


### PR DESCRIPTION
Closes #30

Integrates [httrace](https://httrace.com) as a feature-gated optional integration, following the existing `FEATURE_*` pattern used by audit-log, rate-limiting, logfire, etc.

## What was added

- `FEATURE_HTTRACE` flag (default: `false`) - zero runtime cost when disabled
- `HTTRACE_API_KEY`, `HTTRACE_SERVICE`, `HTTRACE_SAMPLE_RATE` settings
- `httrace` optional dependency (`uv sync --extra httrace`)
- Middleware registered in `create_app()` only when flag and API key are set

## Usage

```env
FEATURE_HTTRACE=true
HTTRACE_API_KEY=ht_...
HTTRACE_SERVICE=ai-template
HTTRACE_SAMPLE_RATE=0.1
```

## Files changed

- `backend/src/dogeapi/settings.py` - 4 new settings
- `backend/src/dogeapi/main.py` - middleware block after FEATURE_AI_CHAT
- `backend/pyproject.toml` - httrace optional dependency and mypy override